### PR TITLE
Negative Seconds with fractional seconds had the wrong sign

### DIFF
--- a/lib/DateTime/Format/Pg.pm
+++ b/lib/DateTime/Format/Pg.pm
@@ -626,9 +626,9 @@ sub parse_duration {
             }
 
             # From the spec, Pg can take up to 6 digits for fractional part
-            # (duh, as 1 sec = 1_000_000 nano sec). If we're missing 0's,
+            # that is microseconds. If we're missing 0's,
             # we should pad them
-            $fractional .= '0'x (6 - length($fractional));
+            $fractional .= '0'x (9 - length($fractional));
             my $sign = ($amount > 0) ? 1 : -1;
             push @extra_args, ("nanoseconds" => $sign * $fractional);
         }

--- a/lib/DateTime/Format/Pg.pm
+++ b/lib/DateTime/Format/Pg.pm
@@ -592,7 +592,7 @@ sub parse_duration {
 
     $string =~ s/\b(\d+):(\d\d):(\d\d)(\.\d+)?\b/$1h $2m $3$4s/g;
     $string =~ s/\b(\d+):(\d\d)\b/$1h $2m/g;
-    $string =~ s/(-\d+h)\s+(\d+m)\s+(\d+s)\s*/$1 -$2 -$3 /;
+    $string =~ s/(-\d+h)\s+(\d+m)\s+(\d+(?:\.\d+)?s)\s*/$1 -$2 -$3 /;
     $string =~ s/(-\d+h)\s+(\d+m)\s*/$1 -$2 /;
 
     while ($string =~ s/^\s*(-?\d+(?:[.,]\d+)?)\s*([a-zA-Z]+)(?:\s*(?:,|and)\s*)*//i) {
@@ -629,7 +629,8 @@ sub parse_duration {
             # (duh, as 1 sec = 1_000_000 nano sec). If we're missing 0's,
             # we should pad them
             $fractional .= '0'x (6 - length($fractional));
-            push @extra_args, ("nanoseconds" => $fractional);
+            my $sign = ($amount > 0) ? 1 : -1;
+            push @extra_args, ("nanoseconds" => $sign * $fractional);
         }
 
         $du->$arith_method($base_unit => $amount * $num, @extra_args);

--- a/t/gh12.t
+++ b/t/gh12.t
@@ -15,6 +15,6 @@ if (! ok !$e, "should succeed parsing '$offset' without errors") {
 }
 
 is $duration->seconds, 28, "seconds should be '28'";
-is $duration->nanoseconds, 369220, "seconds should be '369220'";
+is $duration->nanoseconds, 369220000, "nano-seconds should be '369220000'";
 
 done_testing;

--- a/t/parse_interval.t
+++ b/t/parse_interval.t
@@ -33,6 +33,13 @@ BEGIN
         [ '-1 days'   => DateTime::Duration->new(days => -1)    ],
         [ '-23:59'    => DateTime::Duration->new(hours => -23, minutes => -59) ],
         [ '-1 days -00:01' => DateTime::Duration->new( days => -1, minutes => -1) ],
+        [ '-1 days -20:30:56.123456' => DateTime::Duration->new( 
+                days => -1, 
+                minutes => -1230,  # = 20 * 60 + 30
+                seconds => -56,
+                nanoseconds => -123456,
+            ),
+        ],
         [ '1 mon -1 days' => DateTime::Duration->new(months => 1)->add(days => -1) ],
         [ '1 day 1 month' => DateTime::Duration->new(months => 1)->add(days => 1) ],
         [ '1 month -1 days' => DateTime::Duration->new(months => 1)->add(days => -1) ],

--- a/t/parse_interval.t
+++ b/t/parse_interval.t
@@ -37,7 +37,7 @@ BEGIN
                 days => -1, 
                 minutes => -1230,  # = 20 * 60 + 30
                 seconds => -56,
-                nanoseconds => -123456,
+                nanoseconds => -123456000,
             ),
         ],
         [ '1 mon -1 days' => DateTime::Duration->new(months => 1)->add(days => -1) ],


### PR DESCRIPTION
For an negative interval if, the seconds part has a fractional part. The existing code will consider the seconds to be positive - causing the result to be up to about 2 minutes out, the added test without the fix gives 
[prove.txt](https://github.com/lestrrat-p5/DateTime-Format-Pg/files/2382541/prove.txt)


